### PR TITLE
corrected directory organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ git clone https://github.com/castorini/Anserini.git
 cd Anserini
 mvn clean package appassembler:assemble
 tar xvfz eval/trec_eval.9.0.4.tar.gz -C eval/ && cd eval/trec_eval.9.0.4 && make
-cd ndeval && make
+cd ../ndeval && make
 ```
 
 Now we can index the corpus (.cbor files):

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ sudo apt-get install maven
 git clone https://github.com/castorini/Anserini.git
 cd Anserini
 mvn clean package appassembler:assemble
-tar xvfz eval/trec_eval.9.0.4.tar.gz && cd eval/trec_eval.9.0.4 && make
+tar xvfz eval/trec_eval.9.0.4.tar.gz -C eval/ && cd eval/trec_eval.9.0.4 && make
 cd ndeval && make
 ```
 


### PR DESCRIPTION
Keeps the extracted files inside the `eval` directory. In original form, it throws an error saying that couldn't find `trec_eval.9.0.4` directory after extraction.